### PR TITLE
Add options grid and CRUD operations

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -29,19 +29,30 @@
         private void InitializeComponent()
         {
             dataTable1 = new DataGridView();
+            dataOpciones = new DataGridView();
             btnTraer = new Button();
             cmbSecciones = new ComboBox();
             ((System.ComponentModel.ISupportInitialize)dataTable1).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)dataOpciones).BeginInit();
             SuspendLayout();
             // 
             // dataTable1
             // 
-            dataTable1.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            dataTable1.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             dataTable1.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             dataTable1.Location = new Point(12, 86);
             dataTable1.Name = "dataTable1";
-            dataTable1.Size = new Size(776, 340);
+            dataTable1.Size = new Size(776, 250);
             dataTable1.TabIndex = 0;
+
+            // dataOpciones
+            //
+            dataOpciones.Anchor = AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            dataOpciones.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dataOpciones.Location = new Point(12, 350);
+            dataOpciones.Name = "dataOpciones";
+            dataOpciones.Size = new Size(776, 150);
+            dataOpciones.TabIndex = 3;
             // 
             // btnTraer
             // 
@@ -69,16 +80,19 @@
             ClientSize = new Size(800, 545);
             Controls.Add(cmbSecciones);
             Controls.Add(btnTraer);
+            Controls.Add(dataOpciones);
             Controls.Add(dataTable1);
             Name = "Form1";
             Text = "Form1";
             ((System.ComponentModel.ISupportInitialize)dataTable1).EndInit();
+            ((System.ComponentModel.ISupportInitialize)dataOpciones).EndInit();
             ResumeLayout(false);
         }
 
         #endregion
 
         private DataGridView dataTable1;
+        private DataGridView dataOpciones;
         private Button btnTraer;
         private ComboBox cmbSecciones;
     }

--- a/Form1.cs
+++ b/Form1.cs
@@ -1,15 +1,29 @@
 ﻿using ClosedXML.Excel;
 using System.Windows.Forms;
+using System.Drawing;
 
 namespace Cerene_App
 {
     public partial class Form1 : Form
     {
         private List<Pregunta> List_preguntas;
+        private List<OpcionRespuesta> CatalogoOpciones = new();
         public Form1()
         {
             InitializeComponent();
             List_preguntas = new();
+            dataTable1.AllowUserToAddRows = true;
+            dataTable1.AllowUserToDeleteRows = true;
+            dataOpciones.AllowUserToAddRows = true;
+            dataOpciones.AllowUserToDeleteRows = true;
+            dataTable1.SelectionChanged += dataTable1_SelectionChanged;
+            dataTable1.UserAddedRow += dataTable1_UserAddedRow;
+            dataTable1.UserDeletingRow += dataTable1_UserDeletingRow;
+            dataTable1.CellValueChanged += dataTable1_CellValueChanged;
+
+            dataOpciones.UserAddedRow += dataOpciones_UserAddedRow;
+            dataOpciones.UserDeletingRow += dataOpciones_UserDeletingRow;
+            dataOpciones.CellValueChanged += dataOpciones_CellValueChanged;
         }
 
         private void btnTraer_Click(object sender, EventArgs e)
@@ -26,10 +40,16 @@ namespace Cerene_App
 
                 Importar(ofd.FileName, out preguntas, out catalogo);
 
-                MostrarEnTabla(preguntas); // este método lo puedes crear abajo
+                MostrarEnTabla(preguntas);
                 var secciones = preguntas.Select(p => p.Seccion).Distinct().ToList();
                 List_preguntas = new(preguntas);
+                CatalogoOpciones = new(catalogo);
                 cmbSecciones.DataSource = secciones;
+                if (dataTable1.Rows.Count > 0)
+                {
+                    dataTable1.Rows[0].Selected = true;
+                    MostrarOpciones(List_preguntas[0].Opciones);
+                }
             }
 
          
@@ -40,6 +60,10 @@ namespace Cerene_App
             string seccionSeleccionada = cmbSecciones.SelectedItem.ToString();
             var filtradas = List_preguntas.Where(p => p.Seccion == seccionSeleccionada).ToList();
             MostrarEnTabla(filtradas);
+            if (filtradas.Count > 0)
+            {
+                MostrarOpciones(filtradas[0].Opciones);
+            }
         }
         private void MostrarEnTabla(List<Pregunta> preguntas)
         {
@@ -65,6 +89,12 @@ namespace Cerene_App
                     p.OpcionesResumen,
                     p.RespuestaCorrecta?.Texto ?? ""
                 );
+            }
+
+            if (preguntas.Count > 0)
+            {
+                dataTable1.Rows[0].Selected = true;
+                MostrarOpciones(preguntas[0].Opciones);
             }
         }
 
@@ -144,6 +174,114 @@ namespace Cerene_App
                         p.RespuestaCorrecta?.Texto ?? ""
                     );
                 }
+            }
+        }
+
+        private void dataTable1_SelectionChanged(object sender, EventArgs e)
+        {
+            if (dataTable1.SelectedRows.Count > 0)
+            {
+                int idx = dataTable1.SelectedRows[0].Index;
+                if (idx >= 0 && idx < List_preguntas.Count)
+                {
+                    MostrarOpciones(List_preguntas[idx].Opciones);
+                }
+            }
+        }
+
+        private void MostrarOpciones(List<OpcionRespuesta> opciones)
+        {
+            dataOpciones.Rows.Clear();
+            dataOpciones.Columns.Clear();
+            dataOpciones.Columns.Add("Id", "Id");
+            dataOpciones.Columns.Add("Texto", "Opción");
+
+            foreach (var o in opciones)
+            {
+                dataOpciones.Rows.Add(o.Id, o.Texto);
+            }
+        }
+
+        private void dataTable1_UserAddedRow(object sender, DataGridViewRowEventArgs e)
+        {
+            if (e.Row.Index >= List_preguntas.Count)
+            {
+                List_preguntas.Add(new Pregunta());
+            }
+        }
+
+        private void dataTable1_UserDeletingRow(object sender, DataGridViewRowCancelEventArgs e)
+        {
+            int idx = e.Row.Index;
+            if (idx >= 0 && idx < List_preguntas.Count)
+            {
+                List_preguntas.RemoveAt(idx);
+            }
+        }
+
+        private void dataTable1_CellValueChanged(object sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex < 0 || e.RowIndex >= List_preguntas.Count)
+                return;
+
+            var p = List_preguntas[e.RowIndex];
+            switch (e.ColumnIndex)
+            {
+                case 0:
+                    int.TryParse(dataTable1.Rows[e.RowIndex].Cells[0].Value?.ToString(), out int num);
+                    p.Numero = num;
+                    break;
+                case 1:
+                    p.Texto = dataTable1.Rows[e.RowIndex].Cells[1].Value?.ToString() ?? string.Empty;
+                    break;
+                case 2:
+                    if (Enum.TryParse(dataTable1.Rows[e.RowIndex].Cells[2].Value?.ToString(), out TipoPregunta tipo))
+                        p.Tipo = tipo;
+                    break;
+                case 3:
+                    p.Seccion = dataTable1.Rows[e.RowIndex].Cells[3].Value?.ToString() ?? string.Empty;
+                    break;
+                case 4:
+                    bool.TryParse(dataTable1.Rows[e.RowIndex].Cells[4].Value?.ToString(), out bool mult);
+                    p.Multiple = mult;
+                    break;
+            }
+        }
+
+        private void dataOpciones_UserAddedRow(object sender, DataGridViewRowEventArgs e)
+        {
+            if (dataTable1.SelectedRows.Count == 0) return;
+            int idx = dataTable1.SelectedRows[0].Index;
+            if (idx < 0 || idx >= List_preguntas.Count) return;
+            List_preguntas[idx].Opciones.Add(new OpcionRespuesta());
+        }
+
+        private void dataOpciones_UserDeletingRow(object sender, DataGridViewRowCancelEventArgs e)
+        {
+            if (dataTable1.SelectedRows.Count == 0) return;
+            int idx = dataTable1.SelectedRows[0].Index;
+            if (idx < 0 || idx >= List_preguntas.Count) return;
+            int optIndex = e.Row.Index;
+            if (optIndex >= 0 && optIndex < List_preguntas[idx].Opciones.Count)
+                List_preguntas[idx].Opciones.RemoveAt(optIndex);
+        }
+
+        private void dataOpciones_CellValueChanged(object sender, DataGridViewCellEventArgs e)
+        {
+            if (dataTable1.SelectedRows.Count == 0) return;
+            int idx = dataTable1.SelectedRows[0].Index;
+            if (idx < 0 || idx >= List_preguntas.Count) return;
+            if (e.RowIndex < 0 || e.RowIndex >= List_preguntas[idx].Opciones.Count) return;
+            var opt = List_preguntas[idx].Opciones[e.RowIndex];
+            switch (e.ColumnIndex)
+            {
+                case 0:
+                    int.TryParse(dataOpciones.Rows[e.RowIndex].Cells[0].Value?.ToString(), out int id);
+                    opt.Id = id;
+                    break;
+                case 1:
+                    opt.Texto = dataOpciones.Rows[e.RowIndex].Cells[1].Value?.ToString() ?? string.Empty;
+                    break;
             }
         }
 


### PR DESCRIPTION
## Summary
- add a second datagrid for options
- show option list when selecting a question
- enable editing of questions and options

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68897e8bad1c8322bc2e017e94eefee6