### PR TITLE
feat: add section entity and update questions

### DIFF
--- a/CvsTraer.cs
+++ b/CvsTraer.cs
@@ -26,10 +26,10 @@ namespace Cerene_App
         public int Numero { get; set; }
         public string Texto { get; set; }
         public TipoPregunta Tipo { get; set; }
-        public string Seccion { get; set; }
+        public Seccion? Seccion { get; set; }
         public bool Multiple { get; set; }
         public List<OpcionRespuesta> Opciones { get; set; } = new();
-        public OpcionRespuesta RespuestaCorrecta { get; set; }
+        public OpcionRespuesta? RespuestaCorrecta { get; set; }
         public string OpcionesResumen => string.Join(" | ", Opciones.Select(o => o.Texto));
     }
 

--- a/PreguntaForm.cs
+++ b/PreguntaForm.cs
@@ -56,7 +56,7 @@ namespace Cerene_App
                     Numero = (int)numNumero.Value,
                     Texto = txtTexto.Text,
                     Tipo = (TipoPregunta)cmbTipo.SelectedItem!,
-                    Seccion = txtSeccion.Text,
+                    Seccion = new Seccion { Nombre = txtSeccion.Text },
                     Multiple = chkMultiple.Checked
                 };
                 DialogResult = DialogResult.OK;

--- a/Seccion.cs
+++ b/Seccion.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Cerene_App
+{
+    public class Seccion : IEquatable<Seccion>
+    {
+        private string nombre = "General";
+
+        public string Nombre
+        {
+            get => nombre;
+            set => nombre = string.IsNullOrWhiteSpace(value) ? "General" : value;
+        }
+
+        public override string ToString() => Nombre;
+
+        public bool Equals(Seccion? other)
+        {
+            if (other is null) return false;
+            return string.Equals(Nombre, other.Nombre, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object? obj) => obj is Seccion other && Equals(other);
+
+        public override int GetHashCode() => Nombre.GetHashCode();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `Seccion` class to model question sections
- update `Pregunta` and related forms to use `Seccion`
- ensure empty sections default to `General`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897dca2083c8322acaf602cf963709e